### PR TITLE
fix(blog and slug): refactored code to fetch wp data from server inst…

### DIFF
--- a/app/blogs/[slug]/loading.tsx
+++ b/app/blogs/[slug]/loading.tsx
@@ -1,0 +1,8 @@
+import LoadingState from "@/components/Global/LoadingState";
+
+function BlogPostClientLoading(){
+    //this loads while the server is fetching data and cannot load the components yet
+    return <LoadingState />
+}
+
+export default BlogPostClientLoading;

--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -9,6 +9,11 @@ import { getPostForMetadata, WPPost } from '@/utils/wordpressUtils';
 
 // The new Client Component that holds the main page logic
 import BlogPostClient from '@/components/Blogs/BlogPostClient'; // Adjust path if needed
+import { setTimeout } from 'timers/promises';
+import ErrorState from '@/components/Global/ErrorState';
+
+const REVALIDATE_TIME = 60; // Regenerate every 60 seconds
+
 
 // --- Server-Side Metadata Generation (Stays Here) ---
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
@@ -54,13 +59,45 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 }
 
 // --- Server Component Page Structure ---
-export default function BlogPageServer({ params }: { params: { slug: string } }) {
+export default async function BlogPageServer({ params }: { params: { slug: string } }) {
   // This component runs on the server.
   // It can fetch data here if needed *before* rendering the client component,
   // but currently, data fetching is handled client-side in BlogPostClient.
 
+  const slug = params.slug;
+  const validSlug = Array.isArray(slug) ? slug[0] : slug; // Handle array slugs if needed
+  const encodedSlug = encodeURIComponent(validSlug) ;
+
+  const apiUrl = `https://public-api.wordpress.com/wp/v2/sites/prometheusblog2.wordpress.com/posts?slug=${encodedSlug}&_embed`; // Added _embed
+  
+  const res = await fetch(
+    apiUrl, { next: { revalidate: REVALIDATE_TIME } }
+  );
+
+
+  if (!res.ok){
+    const error = await res.json();
+    console.error("Error loading post:", error);
+    // Check if the error indicates a 404
+    if (error.message.includes('404') || error.message.includes('Failed to fetch: 404')) {
+        notFound();
+    }
+    return <ErrorState title='Failed to load posts' errorDetails={error.message} />
+  };
+  
+  const posts: WPPost[] = await res.json();
+  
+
+
+  // Handle Not Found - triggered by SWR error or if post is null after loading
+  const isNotFound = !posts && slug;
+  if (isNotFound) {
+    notFound(); // Trigger Next.js 404 page
+  }
+
+
   // It simply renders the Client Component wrapper.
   // We don't need to pass the slug explicitly because the client component
   // uses `useParams` to get it.
-  return <BlogPostClient />;
+  return <BlogPostClient posts={posts}/>;
 }

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,14 +1,47 @@
-'use client';
 
 import React from 'react';
 import NavbarGroup from '@/components/Global/NavbarGroup';
 import MainSectionBlogsWP from '@/components/Blogs/MainSectionBlogsWP';
+import ErrorState from '@/components/Global/ErrorState';
 
-export default function Page() {
+// Base API URL
+const BASE_API_URL =
+  'https://public-api.wordpress.com/wp/v2/sites/prometheusblog2.wordpress.com/posts';
+// Set a higher per_page value (WordPress max is 100 per page)
+const PER_PAGE = 100;
+
+const REVALIDATE_TIME = 60; // Regenerate every 60 seconds
+
+interface WPPost {
+  id: number;
+  title: { rendered: string };
+  excerpt: { rendered: string };
+  link: string;
+  slug: string;
+  jetpack_featured_media_url?: string;
+}
+
+export default async function Page() {
+  const API_URL = `${BASE_API_URL}?per_page=${PER_PAGE}&page=1`; //always fetches first page
+  const res = await fetch(
+    API_URL, { next: { revalidate: REVALIDATE_TIME } }
+  );
+
+  
+  if (!res.ok){
+    const errorBody = await res.json();
+    return <ErrorState title='Failed to load posts' errorDetails={errorBody.message} />
+  };
+  
+  const data: WPPost[] = await res.json();
+
   return (
     <main className='bg-black'>
       <NavbarGroup />
-      <MainSectionBlogsWP />
+      <MainSectionBlogsWP data={data}/>
     </main>
   );
 }
+
+
+

--- a/components/Blogs/BlogPostClient.tsx
+++ b/components/Blogs/BlogPostClient.tsx
@@ -18,39 +18,43 @@ import PostContentDisplay from '@/components/Blogs/PostContentDisplay';
 
 // Hook and Utils (Utils are fine to import in client components)
 import { useWordPressPost } from '@/hooks/useWordPressPost';
+import { WPPost } from '@/utils/wordpressUtils';
 // WPPost type might be needed if you type props/state here
 // import { WPPost } from '@/utils/wordpressUtils';
 
 const oxaniumFont = Oxanium({ weight: '500', subsets: ['latin'] });
 
 // --- Client-Side Page Component Logic (Moved Here) ---
-export default function BlogPostClient() {
+export default function BlogPostClient({posts}: {posts: WPPost[]}) {
   const params = useParams();
   // Ensure slug is treated as a string, taking the first element if it's an array
   const slugParam = params.slug;
   const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam;
 
   // Use the custom hook to fetch and process data
-  const { post, processedContent, wpStyles, fontLinks, isLoading, error } = useWordPressPost(slug);
+  // const { post, processedContent, wpStyles, fontLinks, isLoading, error } = useWordPressPost(slug);
 
-  // Handle Not Found - triggered by SWR error or if post is null after loading
-  const isNotFound = !isLoading && !error && !post && slug;
-  if (isNotFound) {
-    notFound(); // Trigger Next.js 404 page
-  }
+  const { post, processedContent, wpStyles, fontLinks } = useWordPressPost(posts);
 
-  // Handle Error State
-  if (error) {
-    console.error("Error loading post:", error);
-    // Check if the error indicates a 404
-    if (error.message.includes('404') || error.message.includes('Failed to fetch: 404')) {
-        notFound();
-    }
-    return <ErrorState title='Failed to load post' errorDetails={error.message} />;
-  }
+
+  // // Handle Not Found - triggered by SWR error or if post is null after loading
+  // const isNotFound = !isLoading && !error && !post && slug;
+  // if (isNotFound) {
+  //   notFound(); // Trigger Next.js 404 page
+  // }
+
+  // // Handle Error State
+  // if (error) {
+  //   console.error("Error loading post:", error);
+  //   // Check if the error indicates a 404
+  //   if (error.message.includes('404') || error.message.includes('Failed to fetch: 404')) {
+  //       notFound();
+  //   }
+  //   return <ErrorState title='Failed to load post' errorDetails={error.message} />;
+  // }
 
   // Handle Loading State
-  if (isLoading || !post) {
+  if (!post) {
     return <LoadingState />;
   }
 

--- a/components/Blogs/MainSectionBlogsWP.tsx
+++ b/components/Blogs/MainSectionBlogsWP.tsx
@@ -30,7 +30,8 @@ interface WPPost {
 // Fetcher function to get data from API
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-const MainSectionBlogsWP = () => {
+const MainSectionBlogsWP = (props : {data: WPPost[]}) => {
+  const { data } = props;
   const [page, setPage] = useState(1);
   const [allPosts, setAllPosts] = useState<WPPost[]>([]);
   const [hasMore, setHasMore] = useState(true);
@@ -39,7 +40,7 @@ const MainSectionBlogsWP = () => {
   // Construct API URL with pagination parameters
   const API_URL = `${BASE_API_URL}?per_page=${PER_PAGE}&page=${page}`;
 
-  const { data, error } = useSWR<WPPost[]>(API_URL, fetcher);
+  // const { data, error } = useSWR<WPPost[]>(API_URL, fetcher);
 
   useEffect(() => {
     if (data) {
@@ -84,9 +85,13 @@ const MainSectionBlogsWP = () => {
     }
   };
 
-  if (error) {
-    return <ErrorState title='Failed to load posts' errorDetails={error.message} />;
-  }
+
+  //TODO: handle error
+  // if (error) {
+  //   console.log("Error here!");
+    
+  //   return <ErrorState title='Failed to load posts' errorDetails={error.message} />;
+  // }
 
   if (!data && allPosts.length === 0) {
     return <LoadingState message='Loading blog posts...' />;

--- a/hooks/useWordPressPost.ts
+++ b/hooks/useWordPressPost.ts
@@ -14,19 +14,21 @@ interface UseWordPressPostResult {
   processedContent: string;
   wpStyles: string;
   fontLinks: string[];
-  isLoading: boolean;
-  error: Error | null;
+  // isLoading: boolean;
+  // error: Error | null;
 }
 
-export function useWordPressPost(slug: string | string[] | undefined): UseWordPressPostResult {
-  const validSlug = Array.isArray(slug) ? slug[0] : slug; // Handle array slugs if needed
-  const encodedSlug = validSlug ? encodeURIComponent(validSlug) : null;
+// export function useWordPressPost(slug: string | string[] | undefined): UseWordPressPostResult {
+export function useWordPressPost(posts : WPPost[]): UseWordPressPostResult {
 
-  const apiUrl = encodedSlug
-    ? `https://public-api.wordpress.com/wp/v2/sites/prometheusblog2.wordpress.com/posts?slug=${encodedSlug}&_embed` // Added _embed
-    : null;
+  // const validSlug = Array.isArray(slug) ? slug[0] : slug; // Handle array slugs if needed
+  // const encodedSlug = validSlug ? encodeURIComponent(validSlug) : null;
 
-  const { data: posts, error, isLoading } = useSWR<WPPost[]>(apiUrl, fetcher);
+  // const apiUrl = encodedSlug
+  //   ? `https://public-api.wordpress.com/wp/v2/sites/prometheusblog2.wordpress.com/posts?slug=${encodedSlug}&_embed` // Added _embed
+  //   : null;
+
+  // const { data: posts, error, isLoading } = useSWR<WPPost[]>(apiUrl, fetcher);
 
   const post = useMemo(() => (posts && posts.length > 0 ? posts[0] : null), [posts]);
 
@@ -70,7 +72,7 @@ export function useWordPressPost(slug: string | string[] | undefined): UseWordPr
     processedContent: processedData.processedContent,
     wpStyles: processedData.wpStyles,
     fontLinks: processedData.fontLinks,
-    isLoading: isLoading || (apiUrl !== null && !post && !error), // Adjust loading state
-    error: error ? error : null,
+    // isLoading: isLoading || (apiUrl !== null && !post && !error), // Adjust loading state
+    // error: error ? error : null,
   };
 }


### PR DESCRIPTION
I commented out the old code and added the refactored code where the api call is invoked from the server. It means that the hook useWordPressPost is also refactored to only clean up the data since it is already fetched. The localhost works just like the deployed site when I tested it.